### PR TITLE
Add NewHandler() function

### DIFF
--- a/ab0x.go
+++ b/ab0x.go
@@ -48,6 +48,13 @@ func init() {
 
 }
 
+func NewHandler() *webdav.Handler{
+	return &webdav.Handler{
+		FileSystem: FS,
+		LockSystem: webdav.NewMemLS(),
+	}
+}
+
 // Open a file
 func (hfs *HTTPFS) Open(path string) (http.File, error) {
 	path = hfs.Prefix + path

--- a/ab0x.go
+++ b/ab0x.go
@@ -48,13 +48,6 @@ func init() {
 
 }
 
-func NewHandler() *webdav.Handler{
-	return &webdav.Handler{
-		FileSystem: FS,
-		LockSystem: webdav.NewMemLS(),
-	}
-}
-
 // Open a file
 func (hfs *HTTPFS) Open(path string) (http.File, error) {
 	path = hfs.Prefix + path

--- a/filebox.go
+++ b/filebox.go
@@ -1,0 +1,12 @@
+package swaggerFiles
+
+import (
+	"golang.org/x/net/webdav"
+)
+
+func NewHandler() *webdav.Handler {
+	return &webdav.Handler{
+		FileSystem: FS,
+		LockSystem: webdav.NewMemLS(),
+	}
+}


### PR DESCRIPTION
Related Issue: https://github.com/swaggo/gin-swagger/issues/197

Explain the issue again, we use `swaggerFiles.Handler` directly for accessing some resources, including CSS, JS, etc. However, it is just one single instance.

In `gin-swagger`, we will patch one prefix to this Handler in one setup. 
If we do it twice, `gin-swagger` will patch the Prefix twice and end up making the request from the first prefix invalid.